### PR TITLE
Card clean up

### DIFF
--- a/src/components/Game/Card/Card.js
+++ b/src/components/Game/Card/Card.js
@@ -17,7 +17,10 @@ export default function Card({id, game_id, value, src, defaultVisibility, func})
     }, [value])
 
     useEffect(() => {
-        socket.on(`game:${game_id}:pickdealer-card-selected`, (data) => {
+        // set name here, helps avoid accidental typos
+        const eventName = `game:${game_id}:pickdealer-card-selected`;
+        //gets a reference to the handler, used so socket knows which handler to remove in socket.off
+        const handler = (data) => {
             if (data.cardId === id) {
                 setIsHidden(false);
                 setIsDisabled(true);
@@ -26,9 +29,10 @@ export default function Card({id, game_id, value, src, defaultVisibility, func})
             if (playerId && data.userId === playerId) {
                 dispatch(setHasClicked())
             }
-        })
+        }
+        socket.on(eventName, handler)
         return () => {
-            socket.off(`game:${game_id}:pickdealer-card-selected`);
+            socket.off(eventName, handler);
         }
     }, [dispatch, game_id, playerId, id])
 


### PR DESCRIPTION
This is how it should be cleaned up, however i do not think this is the right way to use socket inside of here. the other PR i made for you shows some basics of making middleware for your socket connections

another thing you may want to look at is socket.io rooms
https://socket.io/docs/v3/rooms/

on the server you would tell a socket to join a 'room' (which would be a game in this case) then you can dispatch events to that 'room' and it would dispatch automatically to all sockets that joined the room.

this would allow an easier version of the listening code for a game, no longer needing the game id.

also i would recommend pulling all 'logic' out of Card and only have it have an onClick function that the Game component uses to dispatch events, it would simplify the code i think and let all of your game code be in one place.

if you are interested, i put a simple ish version of the socket middleware and comments in another PR. i did not test it as i don't have the time, however i can help a bit more if you would want to push more into that.

i personally think it would be more readable and easier to scale.